### PR TITLE
Prerelease v4.4.1-rc1 beta3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,0 @@
-*.xcf filter=lfs diff=lfs merge=lfs -text
-*.ico filter=lfs diff=lfs merge=lfs -text
-*.png filter=lfs diff=lfs merge=lfs -text
-*.jpg filter=lfs diff=lfs merge=lfs -text

--- a/App/AppInfo/Launcher/MattermostPortable.ini
+++ b/App/AppInfo/Launcher/MattermostPortable.ini
@@ -1,6 +1,6 @@
 [Launch]
 AppName=Mattermost
 ProgramExecutable=Mattermost\Mattermost.exe
-CommandLineArguments=--args --data-dir %PAL:DataDir%\Mattermost
+CommandLineArguments=--args --data-dir "%PAL:DataDir%\Mattermost"
 DirectoryMoveOK=yes
 SupportsUNC=yes

--- a/App/AppInfo/appinfo.ini
+++ b/App/AppInfo/appinfo.ini
@@ -18,8 +18,8 @@ Freeware=true
 CommercialUse=true
 
 [Version]
-PackageVersion=4.4.0.0
-DisplayVersion=4.4.0-beta2-uroesch
+PackageVersion=4.4.1.1
+DisplayVersion=4.4.1.rc1-beta3-uroesch
 
 [Control]
 Icons=1

--- a/App/AppInfo/update.ini
+++ b/App/AppInfo/update.ini
@@ -1,10 +1,10 @@
 [Version]
-Package = 4.4.0.0
-Display = 4.4.0-beta2-uroesch
+Package = 4.4.1.1
+Display = 4.4.1.rc1-beta3-uroesch
 
 [Archive]
-URL1         = https://github.com/mattermost/desktop/releases/download/v4.4.0/mattermost-desktop-4.4.0-win-ia32.zip
-Checksum1    = SHA256:E982AB43140732D53D9DEE99A0872376B9F8F843C752448D592B846E5669698D
+URL1         = https://github.com/mattermost/desktop/releases/download/v4.4.1-rc1/mattermost-desktop-4.4.1-rc1-win-ia32.zip
+Checksum1    = SHA256:af3c69038495144672fc146502151f101d6903bbf2acb58d6dc5d140c9a753bd
 FlatArchive1 = True
 TargetName1  = Mattermost
 ExtractName1 =


### PR DESCRIPTION
Summary:
  * Mattermost upstream prerelease v4.4.1-rc1
  * Remove `.gitattributes`
  * Quote command line arguments.